### PR TITLE
Add option to always save to default image path on VTT server

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,8 @@
   "SETTING.tokenSize.hint": "Being quadratic, both width and height are the same value in pixels",
   "SETTING.automaticTokenGeneration.label": "Auto-generate token images",
   "SETTING.automaticTokenGeneration.hint": "Based on the configured token frame, a token will be automatically generated when you create an Actor that already has a valid actor image applied. Mainly used for VTTA-based imports.",
+  "SETTING.forceDefaultPathOnVTTServer.label": "Save VTT server images in the default path every time",
+  "SETTING.forceDefaultPathOnVTTServer.hint": "When saving a token, do not attempt to save in the same directory as the source image; instead save to the default actor-images path (specified above). Useful to keep generated files out of system or module directories.",
   "BLEND_MODE.SOURCE_OVER.description": "This is the default blend mode and draws new shapes on top of the existing canvas content.",
   "BLEND_MODE.SOURCE_IN.description": "The new shape is drawn only where both the new shape and the destination canvas overlap. Everything else is made transparent.",
   "BLEND_MODE.SOURCE_OUT.description": "The new shape is drawn where it doesn't overlap the existing canvas content.",

--- a/src/modules/editor/UI.js
+++ b/src/modules/editor/UI.js
@@ -451,7 +451,8 @@ class UI {
       switch (options.activeSource) {
         case "data":
           // check if the path is set to the root, if that is true redirect to the default path
-          if (isInsideRootDirectory(options.current)) {
+		  // also redirect to default path if user has requested via config
+          if (isInsideRootDirectory(options.current) || game.settings.get(config.module.name, "forceDefaultPathOnVTTServer")) {
             baseTokenFilename = generateDefaultPath();
           } else {
             baseTokenFilename =

--- a/src/modules/editor/UI.js
+++ b/src/modules/editor/UI.js
@@ -451,7 +451,7 @@ class UI {
       switch (options.activeSource) {
         case "data":
           // check if the path is set to the root, if that is true redirect to the default path
-		  // also redirect to default path if user has requested via config
+          // also redirect to default path if user has requested via config
           if (isInsideRootDirectory(options.current) || game.settings.get(config.module.name, "forceDefaultPathOnVTTServer")) {
             baseTokenFilename = generateDefaultPath();
           } else {

--- a/src/modules/settings/index.js
+++ b/src/modules/settings/index.js
@@ -42,6 +42,16 @@ export default function () {
       public: true,
       section: "token",
     },
+	{
+      // Auto-generation of Tokens
+      key: "forceDefaultPathOnVTTServer",
+      type: Boolean,
+      default: false,
+      scope: "world",
+      config: false,
+      public: true,
+      section: "token",
+    },
     {
       // Auto-generation of Tokens
       key: "tokenSize",

--- a/src/modules/settings/index.js
+++ b/src/modules/settings/index.js
@@ -42,16 +42,6 @@ export default function () {
       public: true,
       section: "token",
     },
-	{
-      // Auto-generation of Tokens
-      key: "forceDefaultPathOnVTTServer",
-      type: Boolean,
-      default: false,
-      scope: "world",
-      config: false,
-      public: true,
-      section: "token",
-    },
     {
       // Auto-generation of Tokens
       key: "tokenSize",
@@ -60,6 +50,16 @@ export default function () {
       max: 480,
       step: 20,
       default: 240,
+      scope: "world",
+      config: false,
+      public: true,
+      section: "token",
+    },
+    {
+      // Token image save location
+      key: "forceDefaultPathOnVTTServer",
+      type: Boolean,
+      default: false,
       scope: "world",
       config: false,
       public: true,


### PR DESCRIPTION
Adds a user-configurable option (defaulted to off to maintain consistency with prior versions) which forces any saves to [data] to always use the VTTA default actor-related images directory. Helpful to keep some icons outside of the systems/ or modules/ paths to avoid those files being overwritten.